### PR TITLE
Allow to select an https server / allow the bot to create a room and publish to it

### DIFF
--- a/ci-client/client.ml
+++ b/ci-client/client.ml
@@ -1,5 +1,7 @@
 open Lwt
+open Lwt.Syntax
 open Matrix_ctos
+module Room = Matrix_ctos.Room
 
 type t = {
   server: Http.Server.t;
@@ -41,22 +43,87 @@ let send_message job server auth_token txn_id message room_id =
     (Fmt.str "/_matrix/client/r0/rooms/%s/send/%s/%s" room_id "m.room.message"
        txn_id)
     None message Request.encoding Response.encoding auth_token
-  >>= fun _ -> return_unit
+  >|= ignore
 
-let run job _room ctx msg =
-  login job ctx.server (make_login ctx.device ctx.user ctx.pwd)
-  >>= fun login_response ->
+let send_state job server auth_token room_id (state_kind, state, state_key) =
+  Current.Job.log job "Sending state to room `%s`: %s" room_id state_kind;
+  let open Room_event.Put.State_event in
+  Http.put server
+    (Fmt.str "/_matrix/client/r0/rooms/%s/state/%s/%s" room_id state_kind
+       state_key)
+    None state Request.encoding Response.encoding auth_token
+  >|= ignore
+
+let post ~job ~room_id ctx message =
+  let* login_response =
+    login job ctx.server (make_login ctx.device ctx.user ctx.pwd)
+  in
   let auth_token = Login.Post.Response.get_access_token login_response in
-  resolve_alias job ctx.server "#ocaml-matrix:my.domain.name"
-  >>= fun resolved_alias ->
-  let room_id =
-    Option.get (Room.Resolve_alias.Response.get_room_id resolved_alias) in
   let txn_id = Uuidm.(v `V4 |> to_string) in
   let message =
     Room_event.Put.Message_event.Request.make
       ~event:
         (Matrix_common.Events.Event_content.Message.Text
-           (Matrix_common.Events.Event_content.Message.Text.make ~body:msg ()))
+           (Matrix_common.Events.Event_content.Message.Text.make ~body:message
+              ()))
       () in
-  send_message job ctx.server auth_token txn_id message room_id >>= fun () ->
-  logout job ctx.server auth_token >>= fun _ -> Lwt.return_ok ()
+  let* () = send_message job ctx.server auth_token txn_id message room_id in
+  let+ _ = logout job ctx.server auth_token in
+  Ok ()
+
+let create_room ~job server auth_token room (name, topic) =
+  let power_level_content_override =
+    Matrix_common.Events.Event_content.Power_levels.make ~events_default:100 ()
+  in
+  Current.Job.log job "Creating room `%s`" room;
+  let open Room.Create in
+  Http.post server "/_matrix/client/r0/createRoom" None
+    (Request.make ~visibility:Public ~room_alias_name:room ~name ~topic
+       ~power_level_content_override ())
+    Request.encoding Response.encoding auth_token
+
+let update_room ~job server auth_token room_id (name, topic) =
+  Current.Job.log job "Updating room `%s`" room_id;
+  let state_name =
+    Room_event.Put.State_event.Request.make
+      ~event:(Name (Matrix_common.Events.Event_content.Name.make ~name ()))
+      () in
+  let* () =
+    send_state job server auth_token room_id ("m.room.name", state_name, "")
+  in
+  let state_topic =
+    Room_event.Put.State_event.Request.make
+      ~event:(Topic (Matrix_common.Events.Event_content.Topic.make ~topic ()))
+      () in
+  send_state job server auth_token room_id ("m.room.topic", state_topic, "")
+
+let get_room ~job ~alias ~name ~topic ctx =
+  let* login_response =
+    login job ctx.server (make_login ctx.device ctx.user ctx.pwd)
+  in
+  let auth_token = Login.Post.Response.get_access_token login_response in
+  (* we look for the room *)
+  let* existing_room_alias =
+    Lwt.catch
+      (fun () ->
+        let+ alias =
+          resolve_alias job ctx.server ("#" ^ alias ^ ":" ^ ctx.server.host)
+        in
+        Room.Resolve_alias.Response.get_room_id alias)
+      (fun _ -> Lwt.return_none)
+  in
+  let+ room_id =
+    match existing_room_alias with
+    | None ->
+      let+ create_room_response =
+        create_room job ctx.server auth_token alias (name, topic)
+      in
+      Room.Create.Response.get_room_id create_room_response
+    | Some room_id ->
+      Current.Job.log job
+        "Room already exists, making sure it has the correct name and topic.";
+      let+ () = update_room job ctx.server auth_token room_id (name, topic) in
+      room_id
+  in
+  Current.Job.log job "Room id: %s" room_id;
+  Ok room_id

--- a/ci-client/client.ml
+++ b/ci-client/client.ml
@@ -2,8 +2,7 @@ open Lwt
 open Matrix_ctos
 
 type t = {
-  host: string;
-  port: int;
+  server: Http.Server.t;
   device: string option;
   user: string;
   pwd: string;
@@ -16,39 +15,39 @@ let make_login device_id user password =
       (V2 (Authentication.Password.V2.make ~identifier ~password ())) in
   Login.Post.Request.make ~auth ?device_id ()
 
-let login job host port login =
-  Current.Job.log job "Login to host %s and port %d" host port;
+let login job server login =
+  Current.Job.log job "Login to %a and port %d" Http.Server.pp server;
   let open Login.Post in
-  Http.post host port "_matrix/client/r0/login" None login Request.encoding
+  Http.post server "_matrix/client/r0/login" None login Request.encoding
     Response.encoding None
 
-let logout job host port auth_token =
+let logout job server auth_token =
   Current.Job.log job "Logout from server";
   let open Logout.Logout in
-  Http.post host port "_matrix/client/r0/logout" None (Request.make ())
+  Http.post server "_matrix/client/r0/logout" None (Request.make ())
     Request.encoding Response.encoding auth_token
 
-let resolve_alias job host port room_alias =
+let resolve_alias job server room_alias =
   Current.Job.log job "Resolving alias `%s` for room name" room_alias;
   let open Room.Resolve_alias in
-  Http.get host port
+  Http.get server
     (Fmt.str "/_matrix/client/r0/directory/room/%s" room_alias)
     None Response.encoding None
 
-let send_message job host port auth_token txn_id message room_id =
+let send_message job server auth_token txn_id message room_id =
   Current.Job.log job "Sending message to room `%s`" room_id;
   let open Room_event.Put.Message_event in
-  Http.put host port
+  Http.put server
     (Fmt.str "/_matrix/client/r0/rooms/%s/send/%s/%s" room_id "m.room.message"
        txn_id)
     None message Request.encoding Response.encoding auth_token
   >>= fun _ -> return_unit
 
 let run job _room ctx msg =
-  login job ctx.host ctx.port (make_login ctx.device ctx.user ctx.pwd)
+  login job ctx.server (make_login ctx.device ctx.user ctx.pwd)
   >>= fun login_response ->
   let auth_token = Login.Post.Response.get_access_token login_response in
-  resolve_alias job ctx.host ctx.port "#ocaml-matrix:my.domain.name"
+  resolve_alias job ctx.server "#ocaml-matrix:my.domain.name"
   >>= fun resolved_alias ->
   let room_id =
     Option.get (Room.Resolve_alias.Response.get_room_id resolved_alias) in
@@ -59,6 +58,5 @@ let run job _room ctx msg =
         (Matrix_common.Events.Event_content.Message.Text
            (Matrix_common.Events.Event_content.Message.Text.make ~body:msg ()))
       () in
-  send_message job ctx.host ctx.port auth_token txn_id message room_id
-  >>= fun () ->
-  logout job ctx.host ctx.port auth_token >>= fun _ -> Lwt.return_ok ()
+  send_message job ctx.server auth_token txn_id message room_id >>= fun () ->
+  logout job ctx.server auth_token >>= fun _ -> Lwt.return_ok ()

--- a/ci-client/client.ml
+++ b/ci-client/client.ml
@@ -18,7 +18,7 @@ let make_login device_id user password =
   Login.Post.Request.make ~auth ?device_id ()
 
 let login job server login =
-  Current.Job.log job "Login to %a and port %d" Http.Server.pp server;
+  Current.Job.log job "Login to %a" Http.Server.pp server;
   let open Login.Post in
   Http.post server "_matrix/client/r0/login" None login Request.encoding
     Response.encoding None

--- a/ci-client/client.mli
+++ b/ci-client/client.mli
@@ -5,4 +5,17 @@ type t = {
   pwd: string;
 }
 
-val run : Current.Job.t -> string -> t -> string -> (unit, string) result Lwt.t
+val post :
+  job:Current.Job.t ->
+  room_id:string ->
+  t ->
+  string ->
+  (unit, string) result Lwt.t
+
+val get_room :
+  job:Current.Job.t ->
+  alias:string ->
+  name:string ->
+  topic:string ->
+  t ->
+  (string, string) result Lwt.t

--- a/ci-client/client.mli
+++ b/ci-client/client.mli
@@ -1,6 +1,5 @@
 type t = {
-  host: string;
-  port: int;
+  server: Http.Server.t;
   device: string option;
   user: string;
   pwd: string;

--- a/ci-client/dune
+++ b/ci-client/dune
@@ -1,7 +1,7 @@
 (library
  (name matrix_current)
  (public_name matrix-current)
- (modules matrix_current post client http)
+ (modules matrix_current post client http room)
  (libraries
   matrix-ctos
   fmt.tty

--- a/ci-client/matrix_current.ml
+++ b/ci-client/matrix_current.ml
@@ -7,8 +7,9 @@ module PC = Current_cache.Output (Post)
 
 type context = Post.t
 
-let context ~host ~port ~user ~pwd ~device =
-  Client.{host; port; user; pwd; device}
+let context ~host ~port ~scheme ~user ~pwd ~device =
+  let server = Http.Server.v scheme host port in
+  Client.{server; user; pwd; device}
 
 let post ctx ~key message =
   Current.component "matrix-post"

--- a/ci-client/matrix_current.mli
+++ b/ci-client/matrix_current.mli
@@ -16,7 +16,29 @@ val context :
     future transactions for per device operations by the matrix server
     (disconnection of a given device, blocking, etc.) *)
 
-val post : context -> key:string -> string Current.t -> unit Current.t
-(** [post context ~key message] records that [key] is now set to [message], and
-    uses a minimalist matrix client to send [message] to every room the user
-    given in [context] is part of. *)
+module Room : sig
+  type t
+
+  val make :
+    context ->
+    alias:string ->
+    ?name:string Current.t ->
+    ?topic:string Current.t ->
+    unit ->
+    t Current.t
+  (** [make context ~alias ~name ~topic ()] manages a room accessible using [alias], 
+      with given [name] and [topic]. It notably makes sure that the room exist and 
+      that it has the chosen name and topic. The user needs rights to create rooms, 
+      and errors might occur if the user don't have rights for a room it needs access 
+      to.*)
+end
+
+val post :
+  context ->
+  key:string ->
+  room:Room.t Current.t ->
+  string Current.t ->
+  unit Current.t
+(** [post context ~key ~room message] records that [key] is now set to [message], and
+    uses a minimalist matrix client to send [message] to [room] using the user
+    given in [context]. *)

--- a/ci-client/matrix_current.mli
+++ b/ci-client/matrix_current.mli
@@ -3,13 +3,14 @@ type context
 val context :
   host:string ->
   port:int ->
+  scheme:[ `Http | `Https ] ->
   user:string ->
   pwd:string ->
   device:string option ->
   context
-(** [post ~host ~port ~user ~password ?device] makes a context for a minimalist matrix
+(** [post ~host ~port ~scheme ~user ~password ?device] makes a context for a minimalist matrix
     client.
-    [host] is the server to be contacted with port [port], while [user] and
+    [host] is the server to be contacted with port [port] using http or https, while [user] and
     [pwd] are the credentials used for the login.
     The optionnal [device] represents the key that will be associated with the
     future transactions for per device operations by the matrix server

--- a/ci-client/post.ml
+++ b/ci-client/post.ml
@@ -4,18 +4,25 @@ type t = Client.t
 
 let id = "matrix-post"
 
-module Key = Current.String
+module Key = struct
+  type t = {key: string; room_id: string}
+
+  let digest {key; room_id} = key ^ "@" ^ room_id
+end
+
 module Value = Current.String
 module Outcome = Current.Unit
 
-let publish t job key message =
+let publish t job {Key.key; room_id} message =
   Current.Job.start job ~level:Current.Level.Above_average >>= fun () ->
   Current.Job.log job "publishing message %S" message;
-  Client.run job key t message >>= function
+  Client.post ~job ~room_id t message >>= function
   | Ok () -> Lwt.return @@ Ok ()
   | Error s ->
     let msg = Fmt.str "Matrix post failed: %s" s in
     Lwt.return @@ Error (`Msg msg)
 
-let pp f (key, value) = Fmt.pf f "Post %s: %s" key value
+let pp f ({Key.key; room_id}, value) =
+  Fmt.pf f "Post %s@%s: %s" key room_id value
+
 let auto_cancel = false

--- a/ci-client/room.ml
+++ b/ci-client/room.ml
@@ -1,0 +1,27 @@
+open Lwt.Infix
+
+type t = Client.t
+
+let id = "matrix-room"
+
+module Key = Current.String
+
+module Value = struct
+  type t = {name: string; topic: string}
+
+  let digest {name; topic} = name ^ ":" ^ topic
+end
+
+module Outcome = Current.String
+
+let publish t job alias Value.{name; topic} =
+  Current.Job.start job ~level:Current.Level.Above_average >>= fun () ->
+  Current.Job.log job "obtaining room %S" name;
+  Client.get_room ~job ~alias ~name ~topic t >>= function
+  | Ok v -> Lwt.return @@ Ok v
+  | Error s ->
+    let msg = Fmt.str "Matrix room failed: %s" s in
+    Lwt.return @@ Error (`Msg msg)
+
+let pp f (alias, _) = Fmt.pf f "Room %S" alias
+let auto_cancel = false


### PR DESCRIPTION
First commit: add a `scheme` option when building the context, group all the server settings in `Http.Server.t`.

Second commit: separate room management and posts.

In the public API now a `Room.t` is required. This `Room.t` corresponds to the ID of a room. 
`Room.make` creates a read-only room managed by the bot with given name and topic. 
In the future we can imagine rooms that the bot would have access to without necessarily having admin rights.