### PR TITLE
Add support for rate-limiting

### DIFF
--- a/ci-client/client.ml
+++ b/ci-client/client.ml
@@ -3,6 +3,73 @@ open Lwt.Syntax
 open Matrix_ctos
 module Room = Matrix_ctos.Room
 
+(* When the server returns a 429 Too Many Requests, instead of failing the request 
+   is re-tried after a delay: either the value as specified by the error message or 1 
+   second by default. *)
+let with_retry_loop fn =
+  let rec loop () =
+    let* result = fn () in
+    match result with
+    | Error Matrix_ctos.Errors.(Rate_limited v) ->
+      let delay_ms =
+        Matrix_ctos.Errors.Rate_limited.get_retry_after_ms v
+        |> Option.value ~default:1000 in
+      let* () = Lwt_unix.sleep (Float.of_int delay_ms /. 1000.) in
+      loop ()
+    | Error e -> raise (Failure (Fmt.to_to_string Matrix_ctos.Errors.pp e))
+    | Ok v -> Lwt.return v in
+  loop ()
+
+let with_pool ~job ~pool fn =
+  let switch = Current.Switch.create ~label:"matrix-client-pool" () in
+  Lwt.finalize
+    (fun () ->
+      let* () = Current.Job.use_pool ~switch job pool in
+      fn ())
+    (fun () -> Current.Switch.turn_off switch)
+
+(* Override Http module with the retry loop and pooling *)
+module Http = struct
+  module Server = Http.Server
+
+  let post
+      ~job
+      ~pool
+      server
+      ?header
+      path
+      args
+      value
+      request_encoding
+      response_encoding
+      auth_token =
+    with_pool ~job ~pool @@ fun () ->
+    with_retry_loop (fun () ->
+        Http.post server ?header path args value request_encoding
+          response_encoding auth_token)
+
+  let get ~job ~pool server ?header path args response_encoding needs_auth =
+    with_pool ~job ~pool @@ fun () ->
+    with_retry_loop (fun () ->
+        Http.get server ?header path args response_encoding needs_auth)
+
+  let put
+      ~job
+      ~pool
+      server
+      ?header
+      path
+      args
+      value
+      request_encoding
+      response_encoding
+      auth_token =
+    with_pool ~job ~pool @@ fun () ->
+    with_retry_loop (fun () ->
+        Http.put server ?header path args value request_encoding
+          response_encoding auth_token)
+end
+
 module Token = struct
   type t = {
     mutex: Lwt_mutex.t;
@@ -14,30 +81,30 @@ module Token = struct
   let v ~server ~login () =
     {server; login; mutex= Lwt_mutex.create (); token= None}
 
-  let login ~job server login =
+  let login ~job ~pool server login =
     Current.Job.log job "Login to %a" Http.Server.pp server;
     let open Login.Post in
-    Http.post server "_matrix/client/r0/login" None login Request.encoding
-      Response.encoding None
+    Http.post ~job ~pool server "_matrix/client/r0/login" None login
+      Request.encoding Response.encoding None
 
-  let login_and_mutate ~job t =
-    let+ response = login ~job t.server t.login in
+  let login_and_mutate ~job ~pool t =
+    let+ response = login ~job ~pool t.server t.login in
     let token = Login.Post.Response.get_access_token response |> Option.get in
     t.token <- Some (token, 1);
     token
 
-  let logout ~job server auth_token =
+  let logout ~job ~pool server auth_token =
     Current.Job.log job "Logout from server";
     let open Logout.Logout in
-    Http.post server "_matrix/client/r0/logout" None (Request.make ())
-      Request.encoding Response.encoding auth_token
+    Http.post ~job ~pool server "_matrix/client/r0/logout" None
+      (Request.make ()) Request.encoding Response.encoding auth_token
 
-  let logout_and_mutate ~job t token =
+  let logout_and_mutate ~job ~pool t token =
     t.token <- None;
-    logout ~job t.server (Some token) |> Lwt.map ignore
+    logout ~job ~pool t.server (Some token) |> Lwt.map ignore
 
-  (** [with_token ~job t fn] ensures a login token is available before calling [fn] with its value. *)
-  let with_token ~job t fn =
+  (** [with_token ~job ~pool t fn] ensures a login token is available before calling [fn] with its value. *)
+  let with_token ~job ~pool t fn =
     Lwt.finalize
       (fun () ->
         let* token =
@@ -45,7 +112,7 @@ module Token = struct
           Lwt_mutex.with_lock t.mutex (fun () ->
               (* increment the reference count, login if no token is available *)
               match t.token with
-              | None -> login_and_mutate ~job t
+              | None -> login_and_mutate ~job ~pool t
               | Some (token, n) ->
                 t.token <- Some (token, n + 1);
                 Lwt.return token)
@@ -57,7 +124,7 @@ module Token = struct
         Lwt_mutex.with_lock t.mutex (fun () ->
             match t.token with
             | None -> Lwt.return_unit
-            | Some (token, 1) -> logout_and_mutate ~job t token
+            | Some (token, 1) -> logout_and_mutate ~job ~pool t token
             | Some (token, n) ->
               t.token <- Some (token, n - 1);
               Lwt.return_unit))
@@ -69,6 +136,7 @@ type t = {
   user: string;
   pwd: string;
   token: Token.t;
+  pool: unit Current.Pool.t;
 }
 
 let make_login device_id user password =
@@ -78,79 +146,95 @@ let make_login device_id user password =
       (V2 (Authentication.Password.V2.make ~identifier ~password ())) in
   Login.Post.Request.make ~auth ?device_id ()
 
-let v ~server ~device ~user ~pwd =
+let v ?(max_connections = 8) ~server ~device ~user ~pwd () =
   let login = make_login device user pwd in
   let token = Token.v ~server ~login () in
-  {server; device; user; pwd; token}
+  {
+    server;
+    device;
+    user;
+    pwd;
+    token;
+    pool=
+      Current.Pool.create
+        ~label:("matrix-client-" ^ server.host)
+        max_connections;
+  }
 
-let resolve_alias job server room_alias =
+let resolve_alias ~job ~pool server room_alias =
   Current.Job.log job "Resolving alias `%s` for room name" room_alias;
   let open Room.Resolve_alias in
-  Http.get server
+  Http.get ~job ~pool server
     (Fmt.str "/_matrix/client/r0/directory/room/%s" room_alias)
     None Response.encoding None
 
-let send_message job server auth_token txn_id message room_id =
+let send_message ~job ~pool server auth_token txn_id message room_id =
   Current.Job.log job "Sending message to room `%s`" room_id;
   let open Room_event.Put.Message_event in
-  Http.put server
+  Http.put ~job ~pool server
     (Fmt.str "/_matrix/client/r0/rooms/%s/send/%s/%s" room_id "m.room.message"
        txn_id)
     None message Request.encoding Response.encoding auth_token
   >|= ignore
 
-let send_state job server auth_token room_id (state_kind, state, state_key) =
+let send_state
+    ~job ~pool server auth_token room_id (state_kind, state, state_key) =
   Current.Job.log job "Sending state to room `%s`: %s" room_id state_kind;
   let open Room_event.Put.State_event in
-  Http.put server
+  Http.put ~job ~pool server
     (Fmt.str "/_matrix/client/r0/rooms/%s/state/%s/%s" room_id state_kind
        state_key)
     None state Request.encoding Response.encoding auth_token
   >|= ignore
 
 let post ~job ~room_id ctx message =
-  Token.with_token ~job ctx.token @@ fun auth_token ->
+  let pool = ctx.pool in
+  Token.with_token ~job ~pool ctx.token @@ fun auth_token ->
   let txn_id = Uuidm.(v `V4 |> to_string) in
   let message = Room_event.Put.Message_event.Request.make ~event:message () in
   let+ () =
-    send_message job ctx.server (Some auth_token) txn_id message room_id
+    send_message ~job ~pool ctx.server (Some auth_token) txn_id message room_id
   in
   Ok ()
 
-let create_room ~job server auth_token room (name, topic) =
+let create_room ~job ~pool server auth_token room (name, topic) =
   let power_level_content_override =
     Matrix_common.Events.Event_content.Power_levels.make ~events_default:100 ()
   in
   Current.Job.log job "Creating room `%s`" room;
   let open Room.Create in
-  Http.post server "/_matrix/client/r0/createRoom" None
+  Http.post ~job ~pool server "/_matrix/client/r0/createRoom" None
     (Request.make ~visibility:Public ~room_alias_name:room ~name ~topic
        ~power_level_content_override ())
     Request.encoding Response.encoding auth_token
 
-let update_room ~job server auth_token room_id (name, topic) =
+let update_room ~job ~pool server auth_token room_id (name, topic) =
   Current.Job.log job "Updating room `%s`" room_id;
   let state_name =
     Room_event.Put.State_event.Request.make
       ~event:(Name (Matrix_common.Events.Event_content.Name.make ~name ()))
       () in
   let* () =
-    send_state job server auth_token room_id ("m.room.name", state_name, "")
+    send_state ~job ~pool server auth_token room_id
+      ("m.room.name", state_name, "")
   in
   let state_topic =
     Room_event.Put.State_event.Request.make
       ~event:(Topic (Matrix_common.Events.Event_content.Topic.make ~topic ()))
       () in
-  send_state job server auth_token room_id ("m.room.topic", state_topic, "")
+  send_state ~job ~pool server auth_token room_id
+    ("m.room.topic", state_topic, "")
 
 let get_room ~job ~alias ~name ~topic ctx =
-  Token.with_token ~job ctx.token @@ fun auth_token ->
+  let pool = ctx.pool in
+  Token.with_token ~job ~pool ctx.token @@ fun auth_token ->
   (* we look for the room *)
   let* existing_room_alias =
     Lwt.catch
       (fun () ->
         let+ alias =
-          resolve_alias job ctx.server ("#" ^ alias ^ ":" ^ ctx.server.host)
+          resolve_alias ~job ~pool ctx.server
+            ("#" ^ alias ^ ":" ^ ctx.server.host)
         in
         Room.Resolve_alias.Response.get_room_id alias)
       (fun _ -> Lwt.return_none)
@@ -159,14 +243,14 @@ let get_room ~job ~alias ~name ~topic ctx =
     match existing_room_alias with
     | None ->
       let+ create_room_response =
-        create_room ~job ctx.server (Some auth_token) alias (name, topic)
+        create_room ~job ~pool ctx.server (Some auth_token) alias (name, topic)
       in
       Room.Create.Response.get_room_id create_room_response
     | Some room_id ->
       Current.Job.log job
         "Room already exists, making sure it has the correct name and topic.";
       let+ () =
-        update_room ~job ctx.server (Some auth_token) room_id (name, topic)
+        update_room ~job ~pool ctx.server (Some auth_token) room_id (name, topic)
       in
       room_id
   in

--- a/ci-client/client.mli
+++ b/ci-client/client.mli
@@ -1,7 +1,13 @@
 type t
 
 val v :
-  server:Http.Server.t -> device:string option -> user:string -> pwd:string -> t
+  ?max_connections:int ->
+  server:Http.Server.t ->
+  device:string option ->
+  user:string ->
+  pwd:string ->
+  unit ->
+  t
 
 val post :
   job:Current.Job.t ->

--- a/ci-client/http.mli
+++ b/ci-client/http.mli
@@ -1,0 +1,41 @@
+module Server : sig
+  type scheme = [ `Http | `Https ]
+  type t = {scheme: scheme; host: string; port: int}
+
+  val pp : Format.formatter -> t -> unit
+  val v : scheme -> string -> int -> t
+  val to_uri : t -> string -> (string * string list) list option -> Uri.t
+end
+
+type 'a or_error = ('a, Matrix_ctos.Errors.t) result
+
+val get :
+  Server.t ->
+  ?header:(string * string) list ->
+  string ->
+  (string * string list) list option ->
+  'a Json_encoding.encoding ->
+  string option ->
+  'a or_error Lwt.t
+
+val post :
+  Server.t ->
+  ?header:(string * string) list ->
+  string ->
+  (string * string list) list option ->
+  'a ->
+  'a Json_encoding.encoding ->
+  'b Json_encoding.encoding ->
+  string option ->
+  'b or_error Lwt.t
+
+val put :
+  Server.t ->
+  ?header:(string * string) list ->
+  string ->
+  (string * string list) list option ->
+  'a ->
+  'a Json_encoding.encoding ->
+  'b Json_encoding.encoding ->
+  string option ->
+  'b or_error Lwt.t

--- a/ci-client/matrix_current.ml
+++ b/ci-client/matrix_current.ml
@@ -6,9 +6,9 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 type context = Post.t
 
-let context ~host ~port ~scheme ~user ~pwd ~device =
+let context ?max_connections ~host ~port ~scheme ~user ~pwd ~device () =
   let server = Http.Server.v scheme host port in
-  Client.v ~server ~user ~pwd ~device
+  Client.v ?max_connections ~server ~user ~pwd ~device ()
 
 module Cmdliner = struct
   open Cmdliner
@@ -58,20 +58,30 @@ module Cmdliner = struct
          ["matrix-passfile"]
     |> named (fun x -> `Passfile x)
 
+  let max_connections =
+    Arg.value
+    @@ Arg.opt Arg.(some int) None
+    @@ Arg.info ~doc:"Maximal number of concurrent connections to the server"
+         ~docv:"MATRIX_MAX_CONNECTIONS" ["matrix-max-connections"]
+    |> named (fun x -> `Max_connections x)
+
   let v
       (`Host host)
       (`Port port)
       (`Scheme scheme)
       (`User user)
-      (`Passfile passfile) =
+      (`Passfile passfile)
+      (`Max_connections max_connections) =
     try
       let server = Http.Server.v scheme (Option.get host) port in
       Some
-        (Client.v ~server ~device:None ~user:(Option.get user)
-           ~pwd:(load_file (Option.get passfile) |> String.trim))
+        (Client.v ?max_connections ~server ~device:None ~user:(Option.get user)
+           ~pwd:(load_file (Option.get passfile) |> String.trim)
+           ())
     with Invalid_argument _ -> None
 
-  let v = Term.(const v $ host $ port $ scheme $ user $ passfile)
+  let v =
+    Term.(const v $ host $ port $ scheme $ user $ passfile $ max_connections)
 end
 
 let cmdliner = Cmdliner.v

--- a/ci-client/matrix_current.mli
+++ b/ci-client/matrix_current.mli
@@ -1,12 +1,14 @@
 type context
 
 val context :
+  ?max_connections:int ->
   host:string ->
   port:int ->
   scheme:[ `Http | `Https ] ->
   user:string ->
   pwd:string ->
   device:string option ->
+  unit ->
   context
 (** [post ~host ~port ~scheme ~user ~password ?device] makes a context for a minimalist matrix
     client.

--- a/lib/matrix-ctos/errors.ml
+++ b/lib/matrix-ctos/errors.ml
@@ -16,6 +16,26 @@ module Error = struct
       pf ppf "{errcode: %s; error: %a}" t.errcode (Dump.option string) t.error)
 end
 
+module Rate_limited = struct
+  type t = {errcode: string; error: string; retry_after_ms: int option}
+  [@@deriving accessor]
+
+  let encoding =
+    let to_tuple t = (), t.error, t.retry_after_ms in
+    let of_tuple ((), error, retry_after_ms) =
+      {errcode= "M_LIMIT_EXCEEDED"; error; retry_after_ms} in
+    let with_tuple =
+      obj3
+        (req "errcode" (constant "M_LIMIT_EXCEEDED"))
+        (req "error" string) (opt "retry_after_ms" int) in
+    conv to_tuple of_tuple with_tuple
+
+  let pp ppf t =
+    Fmt.(
+      pf ppf "{errcode: %s; error: %s; retry_after_ms: %a}" t.errcode t.error
+        (Dump.option int) t.retry_after_ms)
+end
+
 module Auth_error = struct
   module Flow = struct
     type t = {stages: string list} [@@deriving accessor]
@@ -74,21 +94,28 @@ module Auth_error = struct
         t.session)
 end
 
-type t = Error of Error.t | Auth_error of Auth_error.t
+type t =
+  | Error of Error.t
+  | Auth_error of Auth_error.t
+  | Rate_limited of Rate_limited.t
 
 let encoding =
   union
     [
-      case Error.encoding
-        (function Error t -> Some t | _ -> None)
-        (fun t -> Error t);
+      case Rate_limited.encoding
+        (function Rate_limited t -> Some t | _ -> None)
+        (fun t -> Rate_limited t);
       case Auth_error.encoding
         (function Auth_error t -> Some t | _ -> None)
         (fun t -> Auth_error t);
+      case Error.encoding
+        (function Error t -> Some t | _ -> None)
+        (fun t -> Error t);
     ]
 
 let pp ppf = function
   | Error t -> Fmt.pf ppf "Error of %a" Error.pp t
   | Auth_error t -> Fmt.pf ppf "Auth_error of %a" Auth_error.pp t
+  | Rate_limited t -> Fmt.pf ppf "Rate_limited of %a" Rate_limited.pp t
 
 exception Error_excpt of t

--- a/lib/matrix-ctos/matrix_ctos.mli
+++ b/lib/matrix-ctos/matrix_ctos.mli
@@ -528,6 +528,13 @@ module Errors : sig
     val pp : t Fmt.t
   end
 
+  module Rate_limited : sig
+    type%accessor t = {errcode: string; error: string; retry_after_ms: int option}
+
+    val encoding : t encoding
+    val pp : t Fmt.t
+  end
+
   module Auth_error : sig
     module Flow : sig
       type%accessor t = {stages: string list}
@@ -549,7 +556,7 @@ module Errors : sig
     val pp : t Fmt.t
   end
 
-  type t = Error of Error.t | Auth_error of Auth_error.t
+  type t = Error of Error.t | Auth_error of Auth_error.t | Rate_limited of Rate_limited.t
 
   val encoding : t encoding
   val pp : t Fmt.t


### PR DESCRIPTION
- matrix-ctos: add the `Rate_limited` error type
- ci-client: modify `Http` functions to return a result type instead of
  exceptions (still does an exception when failing to parse the json
  message)
- ci-client: modify `Client` to retry requests when receiving a
  Rate_limited error type.
- ci-client: modify `Client` to use a client-wise pool to limit the
  number of concurrent requests
- ci-client: add the maximum number of concurrent requests an option and
  add the appropriate command line argument


**Warning**: for the error type encoding in matrix-ctos, the order matters because `Rate_limited` has to be parsed before `Error` which is more general. 