### PR TITLE
Add CI and fix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 4.12.x
           - 4.13.x
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,14 @@ jobs:
           - ubuntu-latest
         ocaml-compiler:
           - 4.13.x
+        package:
+          - matrix-stos
+          - matrix-ctos
+          - matrix-server
+          - matrix-ci-server
+          - matrix-ci-server-setup
+          - matrix-common
+          - matrix-current
 
     runs-on: ${{ matrix.os }}
 
@@ -28,7 +36,8 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
 
-      - run: opam install . --deps-only --with-test
+      - run: opam install ${{ matrix.package }} --deps-only --with-test
 
-      - run: opam exec -- dune build
+      - run: opam exec -- dune build -p ${{ matrix.package }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.12.x
+          - 4.13.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install . --deps-only --with-test
+
+      - run: opam exec -- dune build

--- a/ci-server/client_routes.ml
+++ b/ci-server/client_routes.ml
@@ -6,7 +6,7 @@ open Common_routes
 module Make
     (Pclock : Mirage_clock.PCLOCK)
     (Time : Mirage_time.S)
-    (Stack : Mirage_stack.V4V6) =
+    (Stack : Tcpip.Stack.V4V6) =
 struct
   module Dream = Dream__mirage.Mirage.Make (Pclock) (Time) (Stack)
   module Middleware = Middleware.Make (Pclock) (Time) (Stack)

--- a/ci-server/dune
+++ b/ci-server/dune
@@ -18,7 +18,7 @@
   irmin-unix
   uuidm
   mirage-time
-  mirage-stack)
+  tcpip)
  (preprocess
   (pps lwt_ppx)))
 

--- a/ci-server/federation_routes.ml
+++ b/ci-server/federation_routes.ml
@@ -10,7 +10,7 @@ open Common_routes
 module Make
     (Pclock : Mirage_clock.PCLOCK)
     (Time : Mirage_time.S)
-    (Stack : Mirage_stack.V4V6) =
+    (Stack : Tcpip.Stack.V4V6) =
 struct
   module Dream = Dream__mirage.Mirage.Make (Pclock) (Time) (Stack)
   module Middleware = Middleware.Make (Pclock) (Time) (Stack)

--- a/ci-server/helper.ml
+++ b/ci-server/helper.ml
@@ -4,7 +4,7 @@ open Store
 module Make
     (Pclock : Mirage_clock.PCLOCK)
     (Time : Mirage_time.S)
-    (Stack : Mirage_stack.V4V6) =
+    (Stack : Tcpip.Stack.V4V6) =
 struct
   module Dream = Dream__mirage.Mirage.Make (Pclock) (Time) (Stack)
 

--- a/ci-server/middleware.ml
+++ b/ci-server/middleware.ml
@@ -4,7 +4,7 @@ open Matrix_stos
 module Make
     (Pclock : Mirage_clock.PCLOCK)
     (Time : Mirage_time.S)
-    (Stack : Mirage_stack.V4V6) =
+    (Stack : Tcpip.Stack.V4V6) =
 struct
   module Dream = Dream__mirage.Mirage.Make (Pclock) (Time) (Stack)
   module Paf = Paf_mirage.Make (Time) (Stack)

--- a/matrix-ci-server-setup.opam
+++ b/matrix-ci-server-setup.opam
@@ -11,6 +11,7 @@ depends: [
   "odoc" {with-doc}
   "matrix-ctos" {= version}
   "matrix-stos" {= version}
+  "lwt_ppx"
   "astring"
   "base64"
   "bheap"

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -24,6 +24,7 @@ depends: [
   "logs"
   "mirage-crypto-ec"
   "mirage-time"
+  "mirage-time-unix"
   "mirage-kv"
   "ppxlib"
   "uuidm"

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -11,6 +11,7 @@ depends: [
   "odoc" {with-doc}
   "matrix-ctos" {= version}
   "matrix-stos" {= version}
+  "lwt_ppx"
   "astring"
   "base64"
   "bheap"

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -11,6 +11,7 @@ depends: [
   "odoc" {with-doc}
   "matrix-ctos" {= version}
   "matrix-stos" {= version}
+  "dream-mirage"
   "lwt_ppx"
   "astring"
   "base64"
@@ -27,6 +28,11 @@ depends: [
   "ppxlib"
   "uuidm"
   "x509"
+]
+pin-depends: [
+  ["dream.~dev"         "git+https://github.com/clecat/dream.git"]
+  ["dream-mirage.~dev"  "git+https://github.com/clecat/dream.git"]
+  ["dream-pure.~dev"    "git+https://github.com/clecat/dream.git"]
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -22,6 +22,7 @@ depends: [
   "irmin-fs"
   "irmin-unix"
   "logs"
+  "tcpip" {>= "7.0.0"}
   "mirage-crypto-ec"
   "mirage-time"
   "mirage-time-unix"

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -25,6 +25,8 @@ depends: [
   "mirage-crypto-ec"
   "mirage-time"
   "mirage-time-unix"
+  "mirage-clock-unix"
+  "mirage-crypto-rng-mirage"
   "mirage-kv"
   "ppxlib"
   "uuidm"

--- a/matrix-common.opam
+++ b/matrix-common.opam
@@ -11,6 +11,7 @@ depends: [
   "ezjsonm"
   "fmt"
   "logs"
+  "cmdliner"
   "ppxlib"
 ]
 build: [

--- a/matrix-current.opam
+++ b/matrix-current.opam
@@ -9,6 +9,7 @@ depends: [
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "matrix-ctos" {= version}
+  "current"
   "cohttp"
   "cohttp-lwt"
   "cohttp-lwt-unix"


### PR DESCRIPTION
This PR adds a github action that performs a `dune build` to check that this projects can build from scratch. 

Missing dependencies are added, and a deprecated module is replaced. 


This PR is draft because it depends on https://github.com/clecat/dream/pull/1

Some of the work was already done by @MisterDA in https://github.com/clecat/ocaml-matrix/pull/10 but now we have a more systematic way of testing things.
