### PR TITLE
Depend on OCaml 4.13

### DIFF
--- a/matrix-ci-server-setup.opam
+++ b/matrix-ci-server-setup.opam
@@ -7,6 +7,7 @@ authors: ["Gwenaëlle Lecat <charles-edouard@tarides.com>"]
 homepage: "https://github.com/clecat/ocaml-matrix"
 bug-reports: "https://github.com/clecat/ocaml-matrix/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "matrix-ctos" {= version}

--- a/matrix-ci-server.opam
+++ b/matrix-ci-server.opam
@@ -7,6 +7,7 @@ authors: ["Gwenaëlle Lecat <charles-edouard@tarides.com>"]
 homepage: "https://github.com/clecat/ocaml-matrix"
 bug-reports: "https://github.com/clecat/ocaml-matrix/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "matrix-ctos" {= version}

--- a/matrix-common.opam
+++ b/matrix-common.opam
@@ -6,6 +6,7 @@ authors: ["Gwenaëlle Lecat <charles-edouard@tarides.com>"]
 homepage: "https://github.com/clecat/ocaml-matrix"
 bug-reports: "https://github.com/clecat/ocaml-matrix/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "ezjsonm"

--- a/matrix-ctos.opam
+++ b/matrix-ctos.opam
@@ -6,6 +6,7 @@ authors: ["Gwenaëlle Lecat <charles-edouard@tarides.com>"]
 homepage: "https://github.com/clecat/ocaml-matrix"
 bug-reports: "https://github.com/clecat/ocaml-matrix/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "matrix-common" {= version}

--- a/matrix-current.opam
+++ b/matrix-current.opam
@@ -6,6 +6,7 @@ authors: ["Gwenaëlle Lecat <charles-edouard@tarides.com>"]
 homepage: "https://github.com/clecat/ocaml-matrix"
 bug-reports: "https://github.com/clecat/ocaml-matrix/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "matrix-ctos" {= version}

--- a/matrix-server.opam
+++ b/matrix-server.opam
@@ -6,6 +6,7 @@ authors: ["Gwenaëlle Lecat <charles-edouard@tarides.com>"]
 homepage: "https://github.com/clecat/ocaml-matrix"
 bug-reports: "https://github.com/clecat/ocaml-matrix/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "matrix-ctos" {= version}

--- a/matrix-stos.opam
+++ b/matrix-stos.opam
@@ -6,6 +6,7 @@ authors: ["Gwenaëlle Lecat <charles-edouard@tarides.com>"]
 homepage: "https://github.com/clecat/ocaml-matrix"
 bug-reports: "https://github.com/clecat/ocaml-matrix/issues"
 depends: [
+  "ocaml" {>= "4.13"}
   "dune" {>= "2.8"}
   "odoc" {with-doc}
   "matrix-common" {= version}


### PR DESCRIPTION
ocaml-matrix is using OCaml 4.13 let-punning.

> Let-punning for monadic let: `let* x = x in` can be shortened to
> `let* x in`.